### PR TITLE
Feature/subsets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harfbuzz_rs"
-version = "2.0.2-alpha.0"
+version = "2.2.1"
 authors = ["Manuel Reinhardt <manuel.rhdt@gmail.com>"]
 description = "A high-level interface to HarfBuzz, exposing its most important functionality in a safe manner using Rust."
 repository = "https://github.com/harfbuzz/harfbuzz_rs"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
-# harfbuzz_rs
+# harfbuzz_rs_now
 
-[![Crates.io](https://img.shields.io/crates/v/harfbuzz_rs.svg)](https://crates.io/crates/harfbuzz_rs)
-[![Documentation](https://docs.rs/harfbuzz_rs/badge.svg)](https://docs.rs/harfbuzz_rs)
-[![Build status](https://github.com/harfbuzz/harfbuzz_rs/actions/workflows/rust.yml/badge.svg)](https://github.com/harfbuzz/harfbuzz_rs/actions/workflows/rust.yml)
+[![Crates.io](https://img.shields.io/crates/v/harfbuzz_rs.svg)](https://crates.io/crates/harfbuzz_rs_now)
+[![Documentation](https://docs.rs/harfbuzz_rs_now/badge.svg)](https://docs.rs/harfbuzz_rs_now)
+[![Build status](https://github.com/KonghaYao/harfbuzz_rs_now/actions/workflows/rust.yml/badge.svg)](https://github.com/KonghaYao/harfbuzz_rs_now/actions/workflows/rust.yml)
 
-`harfbuzz_rs` is a high-level interface to HarfBuzz, exposing its most important
-functionality in a safe manner using Rust.
+`harfbuzz_rs_now` is a high-level interface to HarfBuzz, exposing its most important functionality in a safe manner using Rust. And we provide more powerful methods to you.
+
+- [x] normal usage
+- [x] subset font
+- [x] svg string output
 
 # What is HarfBuzz?
 
@@ -21,31 +24,50 @@ To shape a simple string of text you just create a `Font` from a font file, fill
 a `Buffer` with some text and call the `shape` function.
 
 ```rust
-use harfbuzz_rs::*;
+use harfbuzz_rs_now::*;
 
-let path = "path/to/some/font_file.otf";
-let index = 0; //< face index in the font file
-let face = Face::from_file(path, index)?;
-let mut font = Font::new(face);
+fn main() {
+    let path = "./src/SourceSansVariable-Roman.ttf";
+    let index = 0; //< face index in the font file
+    let face = Face::from_file(path, index).unwrap();
+    let mut font = Font::new(face);
 
-let buffer = UnicodeBuffer::new().add_str("Hello World!");
-let output = shape(&font, buffer, &[]);
+    let buffer = UnicodeBuffer::new().add_str("Hello World!");
 
-// The results of the shaping operation are stored in the `output` buffer.
+    let output = shape(&font, buffer, &[]);
 
-let positions = output.get_glyph_positions();
-let infos = output.get_glyph_infos();
+    // The results of the shaping operation are stored in the `output` buffer.
 
-// iterate over the shaped glyphs
-for (position, info) in positions.iter().zip(infos) {
-    let gid = info.codepoint;
-    let cluster = info.cluster;
-    let x_advance = position.x_advance;
-    let x_offset = position.x_offset;
-    let y_offset = position.y_offset;
+    let positions = output.get_glyph_positions();
+    let infos = output.get_glyph_infos();
 
-    // Here you would usually draw the glyphs.
-    println!("gid{:?}={:?}@{:?},{:?}+{:?}", gid, cluster, x_advance, x_offset, y_offset);
+    // iterate over the shaped glyphs
+    for (position, info) in positions.iter().zip(infos) {
+        let gid = info.codepoint;
+        let cluster = info.cluster;
+        let x_advance = position.x_advance;
+        let x_offset = position.x_offset;
+        let y_offset = position.y_offset;
+
+        // Here you would usually draw the glyphs.
+        println!(
+            "gid{:?}={:?}@{:?},{:?}+{:?}",
+            gid, cluster, x_advance, x_offset, y_offset
+        );
+    }
+
+    // render a simple string to svg!
+    let svg_string = font.render_svg_text("Hello World\nI can see you", &[]);
+    
+
+    // create a font subset     
+    let font_subset = subset::Subset::new();
+    font_subset.clear_drop_table(); // I want to keep all table inside this font
+    font_subset.adjust_layout(); // I want to keep all feature and script layout
+
+    let new_font_face = font_subset.run_subset(&face);
+    let binary_data_of_subset = new_font_face.face_data().get_data();
+
 }
 ```
 

--- a/src/subset.rs
+++ b/src/subset.rs
@@ -65,7 +65,7 @@ impl<'a> Subset<'a> {
         }
     }
 
-    pub fn run_subset(&self, face: Owned<Face<'_>>) -> Owned<Face<'_>> {
+    pub fn run_subset(&self, face: &Owned<Face<'_>>) -> Owned<Face<'_>> {
         let result_ptr = unsafe { hb_subset_or_fail(face.as_raw(), self.raw.as_ptr()) };
         let face = Face::from_ptr(result_ptr);
         face
@@ -115,7 +115,7 @@ mod test {
         subset.clear_drop_table();
         subset.adjust_layout();
 
-        let result_face = subset.run_subset(face);
+        let result_face = subset.run_subset(&face);
 
         // match unicode length
         let unicodes = result_face.collect_unicodes();


### PR DESCRIPTION
## Summary by Sourcery

Rename the library to harfbuzz_rs_now and introduce new features for font subsetting and SVG string output. Update the README to reflect these changes and provide usage examples.

New Features:
- Introduce new methods for font subsetting and SVG string output in the harfbuzz_rs_now library.

Enhancements:
- Rename the library from harfbuzz_rs to harfbuzz_rs_now to reflect the new features and improvements.

Documentation:
- Update README.md to reflect the new library name and added features, including examples for font subsetting and SVG rendering.