### PR TITLE
2.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harfbuzz_rs_now"
-version = "2.2.1"
+version = "2.2.2"
 authors = ["Manuel Reinhardt <manuel.rhdt@gmail.com>"]
 description = "A high-level interface to HarfBuzz, exposing its most important functionality in a safe manner using Rust."
 repository = "https://github.com/harfbuzz/harfbuzz_rs"

--- a/src/subset.rs
+++ b/src/subset.rs
@@ -51,6 +51,9 @@ impl<'a> Subset<'a> {
             ));
         }
     }
+    pub fn add_chars(&self, chars: &[u32]) {
+        self.input_unicode_set.add_chars(chars);
+    }
     pub fn adjust_layout(&self) {
         unsafe {
             for iterator in [
@@ -110,7 +113,7 @@ mod test {
         let face = Face::from_file(path, 0).unwrap();
         let subset = Subset::new();
         let chars: [u32; 3] = [32, 33, 34];
-        subset.input_unicode_set.add_chars(&chars);
+        subset.add_chars(&chars);
 
         subset.clear_drop_table();
         subset.adjust_layout();


### PR DESCRIPTION
## Summary by Sourcery

Update the library to version 2.2.2, introducing a new method to add specific characters to a font subset and enhancing the subset creation process to preserve OpenType tables and layout features. Update the README to document these changes.

New Features:
- Introduce the ability to add specific characters to a font subset using the new add_chars method.

Enhancements:
- Refactor the subset creation process to allow for more flexible font manipulation, including preserving OpenType tables and layout features.

Documentation:
- Update README.md to reflect changes in the font subset creation process.